### PR TITLE
add validation using assert sample and rtype

### DIFF
--- a/model/src/pyrenew/process/simplerandomwalk.py
+++ b/model/src/pyrenew/process/simplerandomwalk.py
@@ -3,7 +3,11 @@
 
 import jax.numpy as jnp
 from numpyro.contrib.control_flow import scan
-from pyrenew.metaclass import RandomVariable, SampledValue
+from pyrenew.metaclass import (
+    RandomVariable,
+    SampledValue,
+    _assert_sample_and_rtype,
+)
 
 
 class SimpleRandomWalkProcess(RandomVariable):
@@ -45,6 +49,7 @@ class SimpleRandomWalkProcess(RandomVariable):
         None
         """
         self.name = name
+        self.validate(step_rv=step_rv, init_rv=init_rv)
         self.step_rv = step_rv
         self.init_rv = init_rv
         self.t_start = t_start
@@ -95,9 +100,22 @@ class SimpleRandomWalkProcess(RandomVariable):
         )
 
     @staticmethod
-    def validate():
+    def validate(step_rv: any, init_rv: any) -> None:
         """
-        Validates input parameters, implementation pending.
+        Validates input parameters.
+
+        Parameters
+        ----------
+        step_rv: any
+            step distribution.
+        init_rv: any
+            initial value of the distribution.
+
+        Returns
+        -------
+        None
         """
-        super().validate()
+        _assert_sample_and_rtype(step_rv)
+        _assert_sample_and_rtype(init_rv)
+
         return None


### PR DESCRIPTION
This PR aims to adds validation of `RandomVariables` using `_assert_sample_and_rtype` function. The validation methods currently implemented varies between checking something is a random variable using `isinstance` and checking that the random variable is valid (i.e check `tuple` return type). 

Based on the comments here https://github.com/CDCgov/multisignal-epi-inference/pull/341#issuecomment-2259357623, I think @damonbayer would like to keep the current implementation of `assert isinstance` and maybe add further check with `_assert_sample_and_rtype`? I wanted to confirm my understanding before adding more to this PR