### PR TITLE
make `deptry` checks in CI more fine-grained

### DIFF
--- a/.github/workflows/deptry.yml
+++ b/.github/workflows/deptry.yml
@@ -29,4 +29,6 @@ jobs:
 
       - name: run deptry
         run: |
-          poetry run deptry . --per-rule-ignores "DEP001=pyrenew,DEP001=pytest,DEP003=pytest,DEP001=test"
+          poetry run deptry src/pyrenew --per-rule-ignores "DEP001=pyrenew"
+          poetry run deptry src/test --ignore DEP004 --per-rule-ignores "DEP001=pyrenew,DEP001=test,DEP002=matplotlib"
+        # tests can use dev dependencies (DEP004), main codebase cannot

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,8 @@ optional = true
 [tool.poetry.group.test.dependencies]
 pytest-cov = "^5.0.0"
 pytest-mpl = "^0.17.0"
+scipy = "^1.14.0"
+pytest = "^8.3.2"
 
 [tool.numpydoc_validation]
 checks = [


### PR DESCRIPTION
This refactors things so that there are fewer ignores for the main codebase (`src/pyrenew`) and a separate, less strict check on the testing codebase (`src/test`)