### PR TITLE
Set `find_heuristic_step_size` Default To `True`

### DIFF
--- a/pyrenew/metaclass.py
+++ b/pyrenew/metaclass.py
@@ -352,6 +352,9 @@ class Model(metaclass=ABCMeta):
         if nuts_args is None:
             nuts_args = dict()
 
+        if "find_heuristic_step_size" not in nuts_args:
+            nuts_args["find_heuristic_step_size"] = True
+
         if mcmc_args is None:
             mcmc_args = dict()
 


### PR DESCRIPTION
In PyRenew, `metaclass.py` the `run` method of the `Model` class supports the users passing arguments for NUTS in NumPyro. These arguments are passed by the user as a dictionary during run time. If the user has not passed the argument `find_heuristic_step_size` or if the user has not passed _any_ arguments, then we want, as a result of its enhancement to sampling, `find_heuristic_step_size = True`, which is this PR's goal. See [the NUTS page](https://num.pyro.ai/en/latest/mcmc.html#numpyro.infer.hmc.NUTS) on NumPyro for more detail on the argument.  