### PR TITLE
Cleanup `rtperiodicdiffar`

### DIFF
--- a/docs/source/tutorials/periodic_effects.qmd
+++ b/docs/source/tutorials/periodic_effects.qmd
@@ -27,7 +27,7 @@ from pyrenew import process, deterministic
 rt_proc = process.RtWeeklyDiffARProcess(
     name="rt_weekly_diff",
     offset=0,
-    log_rt_rv=deterministic.DeterministicVariable(
+    log_rt_init_rv=deterministic.DeterministicVariable(
         name="log_rt", value=jnp.array([0.1, 0.2])
     ),
     autoreg_rv=deterministic.DeterministicVariable(

--- a/test/test_rtperiodicdiff.py
+++ b/test/test_rtperiodicdiff.py
@@ -17,7 +17,7 @@ def test_rtweeklydiff() -> None:
     params = {
         "name": "test",
         "offset": 0,
-        "log_rt_rv": DeterministicVariable(
+        "log_rt_init_rv": DeterministicVariable(
             name="log_rt", value=jnp.array([0.1, 0.2])
         ),
         "autoreg_rv": DeterministicVariable(
@@ -65,7 +65,7 @@ def test_rtweeklydiff_no_autoregressive() -> None:
     params = {
         "name": "test",
         "offset": 0,
-        "log_rt_rv": DeterministicVariable(
+        "log_rt_init_rv": DeterministicVariable(
             name="log_rt", value=jnp.array([0.0, 0.0])
         ),
         # No autoregression!
@@ -109,7 +109,7 @@ def test_rtperiodicdiff_smallsample(inits):
     params = {
         "name": "test",
         "offset": 0,
-        "log_rt_rv": DeterministicVariable(
+        "log_rt_init_rv": DeterministicVariable(
             name="log_rt",
             value=inits,
         ),


### PR DESCRIPTION
- [x] Renames internal variables
- [ ] Removes `RtWeeklyDiffARProcess` entirely
- [ ] Makes  `log_rt_init_rv`, `autoreg_rv`, and `periodic_diff_sd_rv` into `non-RandomVariable` arguments to `RtPeriodicDiffARProcess`.