### PR TITLE
Remove UTF-8 Encoding Headers

### DIFF
--- a/pyrenew/convolve.py
+++ b/pyrenew/convolve.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 """
 convolve
 

--- a/pyrenew/deterministic/__init__.py
+++ b/pyrenew/deterministic/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # numpydoc ignore=GL08
 
 from pyrenew.deterministic.deterministic import DeterministicVariable

--- a/pyrenew/deterministic/deterministic.py
+++ b/pyrenew/deterministic/deterministic.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # numpydoc ignore=GL08
 
 from __future__ import annotations

--- a/pyrenew/deterministic/deterministicpmf.py
+++ b/pyrenew/deterministic/deterministicpmf.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # numpydoc ignore=GL08
 
 from __future__ import annotations

--- a/pyrenew/distutil.py
+++ b/pyrenew/distutil.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 """
 distutil
 

--- a/pyrenew/latent/__init__.py
+++ b/pyrenew/latent/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # numpydoc ignore=GL08
 
 from pyrenew.latent.hospitaladmissions import HospitalAdmissions

--- a/pyrenew/latent/hospitaladmissions.py
+++ b/pyrenew/latent/hospitaladmissions.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # numpydoc ignore=GL08
 
 from __future__ import annotations

--- a/pyrenew/latent/infection_functions.py
+++ b/pyrenew/latent/infection_functions.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # numpydoc ignore=GL08
 
 from __future__ import annotations

--- a/pyrenew/latent/infection_initialization_method.py
+++ b/pyrenew/latent/infection_initialization_method.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # numpydoc ignore=GL08
 from abc import ABCMeta, abstractmethod
 

--- a/pyrenew/latent/infection_initialization_process.py
+++ b/pyrenew/latent/infection_initialization_process.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # numpydoc ignore=GL08
 from pyrenew.latent.infection_initialization_method import (
     InfectionInitializationMethod,

--- a/pyrenew/latent/infections.py
+++ b/pyrenew/latent/infections.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # numpydoc ignore=GL08
 
 from __future__ import annotations

--- a/pyrenew/latent/infectionswithfeedback.py
+++ b/pyrenew/latent/infectionswithfeedback.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # numpydoc ignore=GL08
 
 from typing import NamedTuple

--- a/pyrenew/math.py
+++ b/pyrenew/math.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 """
 Helper functions for doing analytical
 and/or numerical calculations about

--- a/pyrenew/mcmcutils.py
+++ b/pyrenew/mcmcutils.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 """
 Utilities to deal with MCMC outputs
 """

--- a/pyrenew/metaclass.py
+++ b/pyrenew/metaclass.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 """
 pyrenew helper classes
 """

--- a/pyrenew/model/__init__.py
+++ b/pyrenew/model/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # numpydoc ignore=GL08
 
 from pyrenew.model.admissionsmodel import HospitalAdmissionsModel

--- a/pyrenew/model/admissionsmodel.py
+++ b/pyrenew/model/admissionsmodel.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # numpydoc ignore=GL08
 
 from __future__ import annotations

--- a/pyrenew/model/rtinfectionsrenewalmodel.py
+++ b/pyrenew/model/rtinfectionsrenewalmodel.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # numpydoc ignore=GL08
 
 from __future__ import annotations

--- a/pyrenew/observation/__init__.py
+++ b/pyrenew/observation/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # numpydoc ignore=GL08
 
 from pyrenew.observation.negativebinomial import NegativeBinomialObservation

--- a/pyrenew/observation/negativebinomial.py
+++ b/pyrenew/observation/negativebinomial.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # numpydoc ignore=GL08
 
 from __future__ import annotations

--- a/pyrenew/observation/poisson.py
+++ b/pyrenew/observation/poisson.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # numpydoc ignore=GL08
 
 from __future__ import annotations

--- a/pyrenew/process/__init__.py
+++ b/pyrenew/process/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # numpydoc ignore=GL08
 
 from pyrenew.process.ar import ARProcess

--- a/pyrenew/process/ar.py
+++ b/pyrenew/process/ar.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # numpydoc ignore=GL08
 
 from __future__ import annotations

--- a/pyrenew/process/differencedprocess.py
+++ b/pyrenew/process/differencedprocess.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # numpydoc ignore=GL08
 
 from __future__ import annotations

--- a/pyrenew/process/iidrandomsequence.py
+++ b/pyrenew/process/iidrandomsequence.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # numpydoc ignore=GL08
 
 import numpyro.distributions as dist

--- a/pyrenew/process/randomwalk.py
+++ b/pyrenew/process/randomwalk.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # numpydoc ignore=GL08
 
 import numpyro.distributions as dist

--- a/pyrenew/randomvariable/__init__.py
+++ b/pyrenew/randomvariable/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # numpydoc ignore=GL08
 
 from pyrenew.randomvariable.distributionalvariable import (

--- a/pyrenew/regression.py
+++ b/pyrenew/regression.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 """
 Helper classes for regression problems
 """

--- a/test/test_latent_admissions.py
+++ b/test/test_latent_admissions.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # numpydoc ignore=GL08
 
 from test.utils import SimpleRt

--- a/test/test_latent_infections.py
+++ b/test/test_latent_infections.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # numpydoc ignore=GL08
 
 from test.utils import SimpleRt

--- a/test/test_leslie_matrix.py
+++ b/test/test_leslie_matrix.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # numpydoc ignore=GL08
 
 import jax.numpy as jnp

--- a/test/test_logistic_susceptibility_adjustment.py
+++ b/test/test_logistic_susceptibility_adjustment.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # numpydoc ignore=GL08
 
 import jax.numpy as jnp

--- a/test/test_model_basic_renewal.py
+++ b/test/test_model_basic_renewal.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # numpydoc ignore=GL08
 
 

--- a/test/test_model_hosp_admissions.py
+++ b/test/test_model_hosp_admissions.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # numpydoc ignore=GL08
 
 

--- a/test/test_observation_negativebinom.py
+++ b/test/test_observation_negativebinom.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # numpydoc ignore=GL08
 
 import numpy as np

--- a/test/test_observation_poisson.py
+++ b/test/test_observation_poisson.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # numpydoc ignore=GL08
 
 import jax.numpy as jnp

--- a/test/test_predictive.py
+++ b/test/test_predictive.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 """
 Ensures that posterior predictive samples are not generated
 when no posterior samples are available.

--- a/test/test_process_asymptotics.py
+++ b/test/test_process_asymptotics.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # numpydoc ignore=GL08
 
 import jax.numpy as jnp

--- a/test/test_random_key.py
+++ b/test/test_random_key.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 """
 Ensures that models created with the same or
 with different random keys behave appropriately.

--- a/test/test_regression.py
+++ b/test/test_regression.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 """
 Tests for regression functionality
 """

--- a/test/test_transformation.py
+++ b/test/test_transformation.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 """
 Tests for transformations
 """

--- a/test/test_transformed_rv_class.py
+++ b/test/test_transformed_rv_class.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 """
 Tests for TransformedVariable class
 """

--- a/test/utils.py
+++ b/test/utils.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 """
 test utilities
 """


### PR DESCRIPTION
Python3 uses UTF-8 encoding by default, so `# -*- coding: utf-8 -*-` in Python file headers is not needed. For clarity and minimalism of code, these are removed in this PR.