### PR TITLE
Modify README With Instantiated Model Information

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,13 +46,10 @@ Install via pip with
 pip install git+https://github.com/CDCgov/PyRenew@main
 ```
 
-## Existing Models
+## Models Implemented With PyRenew
 
-At present, the following models, which exist in external repositories, are written using PyRenew:
-
-`pyrenew-covid-wastewater` (see [here](https://github.com/CDCgov/pyrenew-covid-wastewater)): _Models and infrastructure for forecasting COVID-19 hospitalizations using wastewater data with PyRenew._
-
-`pyrenew-flu-light` (see [here](https://github.com/CDCgov/pyrenew-flu-light/)): _An instantiation in PyRenew of an influenza forecasting model used in the 2023-24 respiratory season._
+- [CDCgov/pyrenew-covid-wastewaterpyrenew-covid-wastewater](https://github.com/CDCgov/pyrenew-covid-wastewater): _Models and infrastructure for forecasting COVID-19 hospitalizations using wastewater data with PyRenew._
+- [CDCgov/pyrenew-flu-light](https://github.com/CDCgov/pyrenew-flu-light/): _An instantiation in PyRenew of an influenza forecasting model used in the 2023-24 respiratory season._
 
 ## Resources
 

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ At present, the following models, which exist in external repositories, are writ
 
 `pyrenew-covid-wastewater` (see [here](https://github.com/CDCgov/pyrenew-covid-wastewater)): _Models and infrastructure for forecasting COVID-19 hospitalizations using wastewater data with PyRenew._
 
-`pyrenew-flu-light` (see [here](https://github.com/CDCgov/pyrenew-flu-light/)): _An instantiation in PyRenew of an [Epidemia](https://imperialcollegelondon.github.io/epidemia/) influenza forecasting model used in the 2023-24 respiratory season._
+`pyrenew-flu-light` (see [here](https://github.com/CDCgov/pyrenew-flu-light/)): _An instantiation in PyRenew of an influenza forecasting model used in the 2023-24 respiratory season._
 
 ## Resources
 

--- a/README.md
+++ b/README.md
@@ -46,6 +46,14 @@ Install via pip with
 pip install git+https://github.com/CDCgov/PyRenew@main
 ```
 
+## Existing Models
+
+At present, the following models, which exist in external repositories, are written using PyRenew:
+
+`pyrenew-covid-wastewater` (see [here](https://github.com/CDCgov/pyrenew-covid-wastewater)): _Models and infrastructure for forecasting COVID-19 hospitalizations using wastewater data with PyRenew._
+
+`pyrenew-flu-light` (see [here](https://github.com/CDCgov/pyrenew-flu-light/)): _An instantiation in PyRenew of an [Epidemia](https://imperialcollegelondon.github.io/epidemia/) influenza forecasting model used in the 2023-24 respiratory season._
+
 ## Resources
 
 * [The MSR Website](https://cdcgov.github.io/PyRenew/tutorials/index.html) provides general documentation and tutorials on using MSR.


### PR DESCRIPTION
PR for 

> There are PyRenew models that now exist in external repositories and, while referenced in Issues and PRs, it also makes sense to clearly indicate where these models exist. The author's expectation is that some people might go to this repository first, when looking for any of the PyRenew-dependent repositories, and not readily be able to find these external PyRenew models.