### PR TITLE
basic tutorial - align comments and code

### DIFF
--- a/docs/source/tutorials/basic_renewal_model.qmd
+++ b/docs/source/tutorials/basic_renewal_model.qmd
@@ -142,7 +142,7 @@ class MyRt(RandomVariable):
             base_rv=RandomWalk(
                 name="log_rt",
                 step_rv=DistributionalVariable(
-                    name="rw_step_rv", distribution=dist.Normal(0, 0.025)
+                    name="rw_step_rv", distribution=dist.Normal(0, sd_rt)
                 ),
             ),
             transforms=t.ExpTransform(),

--- a/docs/source/tutorials/basic_renewal_model.qmd
+++ b/docs/source/tutorials/basic_renewal_model.qmd
@@ -142,7 +142,7 @@ class MyRt(RandomVariable):
             base_rv=RandomWalk(
                 name="log_rt",
                 step_rv=DistributionalVariable(
-                    name="rw_step_rv", distribution=dist.Normal(0, sd_rt)
+                    name="rw_step_rv", distribution=dist.Normal(0, 0.025)
                 ),
             ),
             transforms=t.ExpTransform(),


### PR DESCRIPTION
For step 3 in the tutorial, the code comment says:   "The random walk on log Rt, with an inferred s.d.", but the transformed variable is constructed with fixed s.d. of 0.025, and the variable `sd_rt` is unused.   The change that makes the most sense to me is to plug in the variable `sd_rt` to the constructor for the DistributionVariable.
