### PR TITLE
Coerce input to jax array in _positive_ints_like (#610)

### DIFF
--- a/pyrenew/math.py
+++ b/pyrenew/math.py
@@ -27,7 +27,7 @@ def _positive_ints_like(vec: ArrayLike) -> jnp.ndarray:
     jnp.ndarray
         The resulting array ``[1, ..., n]``.
     """
-    return jnp.arange(1, jnp.size(vec) + 1)
+    return jnp.arange(1, jnp.size(jnp.asarray(vec)) + 1)
 
 
 def neg_MGF(r: float, w: ArrayLike) -> float:


### PR DESCRIPTION
Fixes #610. Passing a plain Python list to `_positive_ints_like` trips JAX's "size requires ndarray or scalar arguments" DeprecationWarning, which the message says will become a hard error in a future JAX release. Since internal callers (neg_MGF, the mean-generation-interval math, r-approximation) and the existing tests do pass lists, this would eventually break those paths, so I wrapped the argument in jnp.asarray before measuring its size.

I ran test/test_math.py::test_positive_ints_like with DeprecationWarning promoted to an error and it goes from one failure to all passing, and the wider test/test_math.py and test/test_integrate_discrete.py suites stay green. Happy to adjust if you'd prefer a different approach. Thanks!