### PR TITLE
throttle dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,10 +5,34 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      # Check for updates to GitHub Actions every week
       interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "America/New_York"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+
   - package-ecosystem: "uv"
     directory: "/"
     schedule:
-      # Check for updates to GitHub Actions every week
       interval: "weekly"
+      day: "monday"
+      time: "09:30"
+      timezone: "America/New_York"
+    versioning-strategy: "increase-if-necessary"
+    open-pull-requests-limit: 3
+    cooldown:
+      default-days: 7
+      semver-major-days: 30
+      semver-minor-days: 7
+      semver-patch-days: 3
+    groups:
+      uv-minor-patch:
+        applies-to: "version-updates"
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"


### PR DESCRIPTION
- Groups all GitHub Actions bumps into one PR.
- Groups routine uv minor/patch updates into one PR.
- Leaves major updates as separate PRs, which is usually worth it because they deserve review.
- Delays fresh releases a bit with cooldown, reducing churn from rapid follow-up releases.
- Keeps pyproject.toml ranges stable with versioning-strategy: increase-if-necessary.
- Lowers the open Dependabot version-update PR cap to 3. GitHub’s default is 5

Security updates are handled differently: grouping can apply to security updates too, but cooldown does not apply to security PRs, and GitHub has a separate security PR limit.